### PR TITLE
Fix ENV-instruction that causes a wrongly-set value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ LABEL maintainer="Raphael Ebner"
 WORKDIR /app
 
 ENV CRON_TIME="* * * * *"
-ENV CERT_OWNER_ID="root"
-ENV CERT_GROUP_ID="root"
+ENV CERT_OWNER_ID="0"
+ENV CERT_GROUP_ID="0"
 
 COPY --from=0 /app/traefik-ssl-certificate-exporter ./
 RUN apt-get update && apt-get install -y cron

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ FROM debian:latest
 LABEL maintainer="Raphael Ebner"
 WORKDIR /app
 
-ENV CRON_TIME = "* * * * *"
-ENV CERT_OWNER_ID = "root"
-ENV CERT_GROUP_ID = "root"
+ENV CRON_TIME "* * * * *"
+ENV CERT_OWNER_ID "root"
+ENV CERT_GROUP_ID "root"
 
 COPY --from=0 /app/traefik-ssl-certificate-exporter ./
 RUN apt-get update && apt-get install -y cron

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ FROM debian:latest
 LABEL maintainer="Raphael Ebner"
 WORKDIR /app
 
-ENV CRON_TIME "* * * * *"
-ENV CERT_OWNER_ID "root"
-ENV CERT_GROUP_ID "root"
+ENV CRON_TIME="* * * * *"
+ENV CERT_OWNER_ID="root"
+ENV CERT_GROUP_ID="root"
 
 COPY --from=0 /app/traefik-ssl-certificate-exporter ./
 RUN apt-get update && apt-get install -y cron


### PR DESCRIPTION
The first space after the ENV-name instructs docker to use the alternative syntax `ENV <key> <value>`, which in this case would set `= root` instead of just `root`.
So either remove the spaces, or use the correct alternative syntax.

See: https://docs.docker.com/engine/reference/builder/#env