### PR TITLE
feat: allow easier cert export on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /app
 ENV CRON_TIME="* * * * *"
 ENV CERT_OWNER_ID="0"
 ENV CERT_GROUP_ID="0"
+ENV ON_START=1
 
 COPY --from=0 /app/traefik-ssl-certificate-exporter ./
 RUN apt-get update && apt-get install -y cron

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Variables:
 | --owner  | CERT_OWNER_ID | ```0 (root)```          | owner for the extracted cert/keys |
 | --group  | CERT_GROUP_ID | ```0 (root)```          | group for the extracted cert/keys |
 | -        | CRON_TIME     | ```* * * * *```         | cron time for the container to extract certs |
+| -        | ON_START      | `1` (true)              | export certs on start |
 
 Input:
 ----------

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,20 @@ export CERT_GROUP_ID
 CURRENTDATE=$(date +'%Y-%m-%d %T')
 echo "${CURRENTDATE}: Docker container has been started. You can find the log file at /var/log/cron.log"
 
+# Set up export script
+cat <<END > /app/cert-export.sh
+#!/usr/bin/env bash
+/app/traefik-ssl-certificate-exporter --source /app/traefik/acme.json --dest /app/certs/ --owner "$CERT_OWNER_ID" --group "$CERT_GROUP_ID"
+END
+chmod +x /app/cert-export.sh
+
+# Run it now
+if [ "$ON_START" == 1 ]; then
+    /app/cert-export.sh
+fi
+
 # Setup a cron schedule
-echo "${CRON_TIME} /app/traefik-ssl-certificate-exporter --source /app/traefik/acme.json --dest /app/certs/ --owner ${CERT_OWNER_ID} --group ${CERT_GROUP_ID} >> /var/log/cron.log 2>&1
+echo "${CRON_TIME} /app/cert-export.sh >> /var/log/cron.log 2>&1
 # This extra line makes it a valid cron" > scheduler.txt
 
 crontab scheduler.txt


### PR DESCRIPTION
- Add `/app/cert-export.sh` shorthand to let admins export certs manually easily.
- Add `$ON_START=1` env variable to ask the container execute a cert export on start.

@moduon MT-700